### PR TITLE
Mysql: add option for using "STOP SLAVE"

### DIFF
--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -460,7 +460,7 @@ sub mysql_lock {
     # This might be a slave database already
     my $slave_status = $mysql_dbh->selectrow_hashref(q{ SHOW SLAVE STATUS });
     $mysql_logfile           = $slave_status->{Master_Log_File};
-    $mysql_position          = $slave_status->{Read_Master_Log_Pos};
+    $mysql_position          = $slave_status->{Exec_Master_Log_Pos};
     $mysql_binlog_do_db      = $slave_status->{Replicate_Do_DB};
     $mysql_binlog_ignore_db  = $slave_status->{Replicate_Ignore_DB};
 


### PR DESCRIPTION
Instead of "FLUSH TABLES WITH READ LOCK"

mysql has an issue with read locks and it's very easy to effectively
lock up your whole DB with a SELECT. If a mysql slave is being
snapshotted, "STOP SLAVE" is enough to ensure no more writes happen and
is guaranteed not to lock the DB.

See: http://www.mysqlperformanceblog.com/2012/03/23/how-flush-tables-with-read-lock-works-with-innodb-tables/
