### PR TITLE
Mysql: kill query on timeout

### DIFF
--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -256,13 +256,16 @@ sub ebs_snapshot {
 
     my $snapshot;
     eval {
-      local $SIG{ALRM} = sub { ualarm(0); die "timeout\n" };
-      ualarm($snapshot_timeout * 1_000_000);
-      $snapshot = $ec2->create_snapshot(
-        VolumeId    => $volume_id,
-        Description => $description,
-      );
+       eval {
+         local $SIG{ALRM} = sub { ualarm(0); die "timeout\n" };
+         ualarm($snapshot_timeout * 1_000_000);
+         $snapshot = $ec2->create_snapshot(
+           VolumeId    => $volume_id,
+           Description => $description,
+         );
+      };
       ualarm(0);
+      die $@ if $@;
     };
     ualarm(0);
     if ( $@  ){
@@ -528,11 +531,13 @@ sub sql_timeout_retry {
   while ( $lock_tries -- ) {
     $Debug and warn "$Prog: ", scalar localtime, ": $description\n";
     eval {
-      ualarm($lock_timeout * 1_000_000);
-      $mysql_dbh->do($sql) unless $Noaction;
-      ualarm(0);
+       eval {
+         ualarm($lock_timeout * 1_000_000);
+         $mysql_dbh->do($sql) unless $Noaction;
+       };
+       ualarm(0);
+       die $@ if $@; 
     };
-    ualarm(0);
     last LOCK unless $@ =~ /timeout/;
 
     if ( $mysql_kill_query ) {


### PR DESCRIPTION
We have an SQL timeout, but it wasn't actually killing the query when
it times out. This is problem when issuing the FLUSH TABLES command
because it occasionally locks up the database if there is a
long-running write query.

Now, we kill the query when the timeout hits which also kills it upon
CTRL-C'ing

See here for the problem (fixes #23):
https://github.com/alestic/ec2-consistent-snapshot/issues/23

Got the idea for the fix from here:
http://www.perlmonks.org/?node_id=885620

I've tested the following:
1. Call: sql_timeout_retry("SELECT SLEEP(60);", 0.5, 10, 5); after
   connecting.
2. Check the processlist while this is happening:
   Before: We see the query in the list all the time because the
          timeout _doesn't_ stop the query
   After:  query is rarely seen in the list cause it times out and is
          killed after 0.5s
3. Interrupt the process (Ctrl-C) while it's happening
   Before: Query is still in the processlist until it finishes
   After: Query is killed when the process is killed.
