### PR TITLE
Pull in upstream changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,18 @@ ec2-consistent-snapshot - Create EBS snapshots on EC2 w/consistent filesystem/db
     times descriptions count has to match volumes count and they will be
     applied on the same order.
 
+- --tag "KEY=VALUE;KEY2=VALUE2"
+
+    If the --tag option is given once, the provided tags will be applied to all
+    created snapshots.  Tag keys and values must be separated by '='. Multiple tags
+    must be separated by ';'.
+
+    If the --tag option is provided more than once, the tags for each use of --tag
+    will apply to each volume in the order that the volumes are provided.
+
+    To check how your tags will be applied, you can use the --noaction flag before
+    actually running a snapshot.
+
 - --freeze-filesystem MOUNTPOINT
 - --xfs-filesystem MOUNTPOINT \[OBSOLESCENT form of the same option\]
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ ec2-consistent-snapshot - Create EBS snapshots on EC2 w/consistent filesystem/db
     Indicates that the volume contains data files for a running MySQL
     database, which will be flushed and locked during the snapshot.
 
+    To connect, we will first look in \`--mysql-defaults-file\`, if provided.
+    Otherwise, the values of \`--mysql-host\`, \`--mysql-socket\`, \`--mysql-username\`
+    and \`--mysql-password\` will be used to build the connection string.
+
 - --mysql-defaults-file FILE
 
     MySQL defaults file, containing host, username and password, this
@@ -137,9 +141,11 @@ ec2-consistent-snapshot - Create EBS snapshots on EC2 w/consistent filesystem/db
 
 - --mysql-stop
 
-    Indicates that the volume contains data files for a running MySQL
-    database.  The database is shutdown before the snapshot is initiated
-    and restarted afterwards. \[EXPERIMENTAL\]
+    Indicates that the volume contains data files for a running MySQL database.
+    The database is shutdown using \`/usr/bin/mysqladmin stop\` before the snapshot
+    is initiated and restarted afterwards using \`/etc/init.d/mysql start\`. Suitable
+    for running as root when a few seconds of downtime are acceptable.
+    \[EXPERIMENTAL\]
 
 - --percona
 

--- a/README.md
+++ b/README.md
@@ -490,11 +490,11 @@ providing feature development, feedback, bug reports, and patches:
 
 # AUTHOR/MAINTAINER
 
-Eric Hammond &lt;ehammond@thinksome.com>
+Eric Hammond <ehammond@thinksome.com>
 
 # LICENSE
 
-Copyright 2009-2015 Eric Hammond &lt;ehammond@thinksome.com>
+Copyright 2009-2015 Eric Hammond <ehammond@thinksome.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,19 @@ ec2-consistent-snapshot - Create EBS snapshots on EC2 w/consistent filesystem/db
     You may specify this option multiple times if you need to freeze multiple
     filesystems on the the EBS volume(s).
 
+    If no EBS volume ids are specified as command arguments, the specified
+    mountpoints will be used along with mount points passed to
+    \--no-freeze-filesystem to determine the volume ids.
+
+- \--no-freeze-filesystem MOUNTPOINT
+
+    Indicates that the filesystem at the specified mount point should be used for
+    volume id discovery if no volume ids are specified as arguments, but that it
+    should not be frozen.
+
+    You may specify this options multiple times if you need to discover EBS volumes
+    for multiple filesystems.
+
 - \--mongo
 
     Indicates that the volume contains data files for a running Mongo
@@ -234,6 +247,11 @@ Snapshot two volumes with customized descriptions:
       --description "Description 2nd Volume"                     \
       vol-VOL1 vol-VOL2
 
+Snapshot a volume without specifying a volume id (requires ec2:DescribeInstances
+permission):
+
+    ec2-consistent-snapshot --freeze-filesystem /vol
+
 # ENVIRONMENT
 
 - $AWS\_ACCESS\_KEY\_ID
@@ -297,9 +315,17 @@ On Ubuntu 8.04 Hardy, use the following commands instead:
 The default values can be accepted for most of the prompts, though it
 is necessary to select a CPAN mirror on Hardy.
 
-On Amazon Linux, Use the following command. 
+# VOLUME DISCOVERY
 
-     yum --enablerepo=epel install perl-Net-Amazon-EC2 perl-File-Slurp perl-DBI perl-DBD-MySQL perl-Net-SSLeay perl-IO-Socket-SSL perl-Time-HiRes perl-Params-Validate perl-DateTime-Format-ISO8601 perl-Date-Manip perl-Moose ca-certificates
+If no EBS volume ids are passed as arguments to ec2-consistent-snapshot, it
+will attempt to discover the volume ids based on the mount points passed to
+\--no-freeze-filesystem and --freeze-filesystem.
+
+In order to determine the volume ids, ec2-consistent-snapshot first makes a
+call to the EC2 instance metadata service to determine the instance's id. Next,
+it makes a call to the DescribeInstances EC2 api to get the list of volumes
+attached to the instance. It then compares the device names for each attachment
+with a list of device names determined using mountpoint(1) and sysfs.
 
 # SEE ALSO
 
@@ -361,6 +387,8 @@ providing feature development, feedback, bug reports, and patches:
     Peter Waller
     yalamber
     Daniel Beardsley
+    dileep-p
+    theonlypippo
 
 # AUTHOR/MAINTAINER
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ ec2-consistent-snapshot - Create EBS snapshots on EC2 w/consistent filesystem/db
 - --use-iam-role
 
     The instance is part of an IAM role that that has permission to create
-    snapshots so there is no need to specify access key or secret.
+    snapshots so there is no need to specify access key or secret. See ["IAM ROLES"](#iam-roles)
+    section for an example Managed Policy with the required permissions.
 
 - --region REGION
 
@@ -321,6 +322,42 @@ On Ubuntu 8.04 Hardy, use the following commands instead:
 The default values can be accepted for most of the prompts, though it
 is necessary to select a CPAN mirror on Hardy.
 
+<a name="iam-roles"></a>
+
+# IAM ROLES
+
+When authenticating using a IAM Role your role must have the appropriate
+permissions.  You can create a single IAM Managed Policy that allows the
+necessary permissions and attach the managed policy to each IAM role you would
+like to allow to create EC2 snapshots.
+
+The following policy allows both creating the snapshots as the read-only
+`DescribeInstances` permission which is required if you want to snapshot a volume
+without specifying the volume ID.
+
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "1",
+                "Effect": "Allow",
+                "Action": [
+                    "ec2:CreateSnapshot",
+                    "ec2:DescribeInstances"
+                ],
+                "Resource": [
+                    "*"
+                ]
+            }
+        ]
+    }
+
+You might also use IAM policies to allow automating deleting old snapshots
+through another tool. Using a separate policy is recommended for that. By
+putting the "delete" permission in the same policy, you would be allowing
+someone with access to one of your EC2 instances to delete the backups of the
+instance volumes. Instead, carefully restrict the delete permission.
+
 # VOLUME DISCOVERY
 
 If no EBS volume ids are passed as arguments to ec2-consistent-snapshot, it
@@ -337,7 +374,7 @@ with a list of device names determined using mountpoint(1) and sysfs.
 
 - Amazon EC2
 - Amazon EC2 EBS (Elastic Block Store)
-- ec2-create-snapshot
+- [aws ec2 create-snapshot](http://docs.aws.amazon.com/cli/latest/reference/ec2/create-snapshot.html)
 
 # CAVEATS
 
@@ -402,11 +439,11 @@ providing feature development, feedback, bug reports, and patches:
 
 # AUTHOR/MAINTAINER
 
-Eric Hammond <ehammond@thinksome.com>
+Eric Hammond &lt;ehammond@thinksome.com>
 
 # LICENSE
 
-Copyright 2009-2014 Eric Hammond <ehammond@thinksome.com>
+Copyright 2009-2014 Eric Hammond &lt;ehammond@thinksome.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -108,18 +108,46 @@ ec2-consistent-snapshot - Create EBS snapshots on EC2 w/consistent filesystem/db
     database, which will be flushed and locked during the snapshot.
 
 - --mongo-host HOST
+
+    Define host used with the \`--mongo\` option.
+
+    Defaults to 'localhost'.
+
 - --mongo-port PORT
+
+    Define MongoDB port used with the \`--mongo\` option.
+
+    Defaults to 27017
+
 - --mongo-username USER
+
+    Define MongoDB username used with the \`--mongo\` option.
+
+    Defaults to \`undef\`. Required only if authentication is required.
+
 - --mongo-password PASS
 
-    Mongo host, port, username, and password used to flush logs if there
-    is authentication required on the admin database.
+    Define MongoDB password used with the \`--mongo\` option.
+
+    Defaults to \`undef\`.  Required only if authentication is required.
 
 - --mongo-stop
 
     Indicates that the volume contains data files for a running Mongo
     instance.  The instance is shutdown before the snapshot is initiated
     and restarted afterwards. \[EXPERIMENTAL\]
+
+    Uses the \`--mongo-init\` option to stop and start the database ignores
+    all other Mongo-related options
+
+- --mongo-init
+
+    The command used to stop and start mongo.
+
+    Defaults to \`/etc/init.d/mongod\`.
+
+    Used only if \`--mongo-stop\` is used. The \`--mongo-init\` command is passed the 'stop' and 'start'
+    options during to the stop/start process.
 
 - --mysql
 
@@ -317,6 +345,29 @@ commands:
     sudo apt-get update
     sudo apt-get install ec2-consistent-snapshot
 
+This program may also require the installation of the Net::Amazon::EC2
+Perl package from CPAN.  On Ubuntu 10.04 Lucid and higher, this should
+happen automatically by the dependency on the libnet-amazon-ec2-perl
+package.
+
+On some earlier releases of Ubuntu you can install the required
+package with the following command:
+
+    sudo PERL_MM_USE_DEFAULT=1 cpan Net::Amazon::EC2
+
+On Ubuntu 8.04 Hardy, use the following commands instead:
+
+    code=$(lsb_release -cs)
+    echo "deb http://ppa.launchpad.net/alestic/ppa/ubuntu $code main"|
+      sudo tee /etc/apt/sources.list.d/alestic-ppa.list
+    sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys BE09C571
+    sudo apt-get update
+    sudo apt-get install ec2-consistent-snapshot build-essential
+    sudo cpan Net::Amazon::EC2
+
+The default values can be accepted for most of the prompts, though it
+is necessary to select a CPAN mirror on Hardy.
+
 <a name="iam-roles"></a>
 
 # IAM ROLES
@@ -439,11 +490,11 @@ providing feature development, feedback, bug reports, and patches:
 
 # AUTHOR/MAINTAINER
 
-Eric Hammond <ehammond@thinksome.com>
+Eric Hammond &lt;ehammond@thinksome.com>
 
 # LICENSE
 
-Copyright 2009-2015 Eric Hammond <ehammond@thinksome.com>
+Copyright 2009-2015 Eric Hammond &lt;ehammond@thinksome.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ with a list of device names determined using mountpoint(1) and sysfs.
 
 - Amazon EC2
 - Amazon EC2 EBS (Elastic Block Store)
-- ec2-create-snapshot
+- [aws ec2 create-snapshot](http://docs.aws.amazon.com/cli/latest/reference/ec2/create-snapshot.html)
 
 # CAVEATS
 

--- a/README.md
+++ b/README.md
@@ -352,6 +352,10 @@ without specifying the volume ID.
         ]
     }
 
+If you get an "unauthorized" error when using the `--use-iam-role` option, you
+can use the `--debug` option to confirm whether it was the
+`DescribeInstances` or `CreateSnapshot` API call that failed.
+
 You might also use IAM policies to allow automating deleting old snapshots
 through another tool. Using a separate policy is recommended for that. By
 putting the "delete" permission in the same policy, you would be allowing
@@ -439,11 +443,11 @@ providing feature development, feedback, bug reports, and patches:
 
 # AUTHOR/MAINTAINER
 
-Eric Hammond &lt;ehammond@thinksome.com>
+Eric Hammond <ehammond@thinksome.com>
 
 # LICENSE
 
-Copyright 2009-2014 Eric Hammond &lt;ehammond@thinksome.com>
+Copyright 2009-2015 Eric Hammond <ehammond@thinksome.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -317,29 +317,6 @@ commands:
     sudo apt-get update
     sudo apt-get install ec2-consistent-snapshot
 
-This program may also require the installation of the Net::Amazon::EC2
-Perl package from CPAN.  On Ubuntu 10.04 Lucid and higher, this should
-happen automatically by the dependency on the libnet-amazon-ec2-perl
-package.
-
-On some earlier releases of Ubuntu you can install the required
-package with the following command:
-
-    sudo PERL_MM_USE_DEFAULT=1 cpan Net::Amazon::EC2
-
-On Ubuntu 8.04 Hardy, use the following commands instead:
-
-    code=$(lsb_release -cs)
-    echo "deb http://ppa.launchpad.net/alestic/ppa/ubuntu $code main"|
-      sudo tee /etc/apt/sources.list.d/alestic-ppa.list
-    sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys BE09C571
-    sudo apt-get update
-    sudo apt-get install ec2-consistent-snapshot build-essential
-    sudo cpan Net::Amazon::EC2
-
-The default values can be accepted for most of the prompts, though it
-is necessary to select a CPAN mirror on Hardy.
-
 <a name="iam-roles"></a>
 
 # IAM ROLES

--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ without specifying the volume ID.
                 "Effect": "Allow",
                 "Action": [
                     "ec2:CreateSnapshot",
+                    "ec2:CreateTags",
                     "ec2:DescribeInstances"
                 ],
                 "Resource": [

--- a/README.md
+++ b/README.md
@@ -127,6 +127,12 @@ ec2-consistent-snapshot - Create EBS snapshots on EC2 w/consistent filesystem/db
     database.  The database is shutdown before the snapshot is initiated
     and restarted afterwards. \[EXPERIMENTAL\]
 
+- \--percona
+
+    Indicates that the volume contains data files for a running Percona/MySQL
+    database, which will be locked using Percona's unique backup locking commands.
+    Note: this sets '--mysql' automatically.
+
 - \--snapshot-timeout SECONDS
 
     How many seconds to wait for the snapshot-create to return.  Defaults

--- a/README.md
+++ b/README.md
@@ -8,52 +8,52 @@ ec2-consistent-snapshot - Create EBS snapshots on EC2 w/consistent filesystem/db
 
 # OPTIONS
 
-- \-h --help
+- -h --help
 
     Print help and exit.
 
-- \-d --debug
+- -d --debug
 
     Debug mode.
 
-- \-q --quiet
+- -q --quiet
 
     Quiet mode.
 
-- \-n --noaction
+- -n --noaction
 
     Dry run. Just say what you would have done, don't do it.
 
-- \--aws-access-key-id KEY
-- \--aws-secret-access-key SECRET
+- --aws-access-key-id KEY
+- --aws-secret-access-key SECRET
 
     Amazon AWS access key and secret access key.  Defaults to
     environment variables or .awssecret file contents described below.
 
-- \--aws-access-key-id-file KEYFILE
-- \--aws-secret-access-key-file SECRETFILE
+- --aws-access-key-id-file KEYFILE
+- --aws-secret-access-key-file SECRETFILE
 
     Files containing Amazon AWS access key and secret access key.
     Defaults to environment variables or .awssecret file contents
     described below.
 
-- \--aws-credentials-file CREDENTIALSFILE
+- --aws-credentials-file CREDENTIALSFILE
 
     File containing both the Amazon AWS access key and secret access
     key on seprate lines and in that order.  Defaults to contents of
     $AWS\_CREDENTIALS environment variable or the value $HOME/.awssecret
 
-- \--use-iam-role
+- --use-iam-role
 
     The instance is part of an IAM role that that has permission to create
     snapshots so there is no need to specify access key or secret.
 
-- \--region REGION
+- --region REGION
 
     Specify a different EC2 region like "eu-west-1".  Defaults to
     "us-east-1".
 
-- \--description DESCRIPTION
+- --description DESCRIPTION
 
     Specify a description string for the EBS snapshot.  Defaults to the
     name of the program.
@@ -63,8 +63,8 @@ ec2-consistent-snapshot - Create EBS snapshots on EC2 w/consistent filesystem/db
     times descriptions count has to match volumes count and they will be
     applied on the same order.
 
-- \--freeze-filesystem MOUNTPOINT
-- \--xfs-filesystem MOUNTPOINT \[OBSOLESCENT form of the same option\]
+- --freeze-filesystem MOUNTPOINT
+- --xfs-filesystem MOUNTPOINT \[OBSOLESCENT form of the same option\]
 
     Indicates that the filesystem at the specified mount point should be
     flushed and frozen during the snapshot. Requires the xfs\_freeze or
@@ -80,7 +80,7 @@ ec2-consistent-snapshot - Create EBS snapshots on EC2 w/consistent filesystem/db
     mountpoints will be used along with mount points passed to
     \--no-freeze-filesystem to determine the volume ids.
 
-- \--no-freeze-filesystem MOUNTPOINT
+- --no-freeze-filesystem MOUNTPOINT
 
     Indicates that the filesystem at the specified mount point should be used for
     volume id discovery if no volume ids are specified as arguments, but that it
@@ -89,90 +89,90 @@ ec2-consistent-snapshot - Create EBS snapshots on EC2 w/consistent filesystem/db
     You may specify this options multiple times if you need to discover EBS volumes
     for multiple filesystems.
 
-- \--mongo
+- --mongo
 
     Indicates that the volume contains data files for a running Mongo
     database, which will be flushed and locked during the snapshot.
 
-- \--mongo-host HOST
-- \--mongo-port PORT
-- \--mongo-username USER
-- \--mongo-password PASS
+- --mongo-host HOST
+- --mongo-port PORT
+- --mongo-username USER
+- --mongo-password PASS
 
     Mongo host, port, username, and password used to flush logs if there
     is authentication required on the admin database.
 
-- \--mongo-stop
+- --mongo-stop
 
     Indicates that the volume contains data files for a running Mongo
     instance.  The instance is shutdown before the snapshot is initiated
     and restarted afterwards. \[EXPERIMENTAL\]
 
-- \--mysql
+- --mysql
 
     Indicates that the volume contains data files for a running MySQL
     database, which will be flushed and locked during the snapshot.
 
-- \--mysql-defaults-file FILE
+- --mysql-defaults-file FILE
 
     MySQL defaults file, containing host, username and password, this
     option will ignore the --mysql-host, --mysql-username,
     \--mysql-password parameters
 
-- \--mysql-host HOST
-- \--mysql-socket PATH
-- \--mysql-username USER
-- \--mysql-password PASS
+- --mysql-host HOST
+- --mysql-socket PATH
+- --mysql-username USER
+- --mysql-password PASS
 
     MySQL host, socket path, username, and password used to flush logs and
     lock tables.  User must have appropriate permissions.  Defaults to
     $HOME/.my.cnf file contents.
 
-- \--mysql-master-status-file FILE
+- --mysql-master-status-file FILE
 
     Store the MASTER STATUS output in a file on the snapshot. It will be
     removed after the EBS snapshot is taken.  This option will be ignored
     with --mysql-stop
 
-- \--mysql-stop
+- --mysql-stop
 
     Indicates that the volume contains data files for a running MySQL
     database.  The database is shutdown before the snapshot is initiated
     and restarted afterwards. \[EXPERIMENTAL\]
 
-- \--percona
+- --percona
 
     Indicates that the volume contains data files for a running Percona/MySQL
     database, which will be locked using Percona's unique backup locking commands.
     Note: this sets '--mysql' automatically.
 
-- \--snapshot-timeout SECONDS
+- --snapshot-timeout SECONDS
 
     How many seconds to wait for the snapshot-create to return.  Defaults
     to 10.0
 
-- \--lock-timeout SECONDS
+- --lock-timeout SECONDS
 
     How many seconds to wait for a database lock. Defaults to 0.5.
     Making this too large can force other processes to wait while this
     process waits for a lock.  Better to make it small and try lots of
     times.
 
-- \--lock-tries COUNT
+- --lock-tries COUNT
 
     How many times to try to get a database lock before failing.  Defaults
     to 60.
 
-- \--lock-sleep SECONDS
+- --lock-sleep SECONDS
 
     How many seconds to sleep between database lock tries.  Defaults
     to 5.0.
 
-- \--pre-freeze-command COMMAND
+- --pre-freeze-command COMMAND
 
     Command to run after MySQL stop/lock and before filesystem freeze.
 
-- \--post-thaw-command COMMAND
+- --post-thaw-command COMMAND
 
     Command to run immediately after filesystem unfreeze and before MySQL
     start/unlock.
@@ -290,7 +290,7 @@ permission):
 
 # INSTALLATION
 
-On most Ubuntu releases, the __ec2-consistent-snapshot__ package can be
+On most Ubuntu releases, the **ec2-consistent-snapshot** package can be
 installed directly from the Alestic.com PPA using the following
 commands:
 
@@ -337,7 +337,7 @@ with a list of device names determined using mountpoint(1) and sysfs.
 
 - Amazon EC2
 - Amazon EC2 EBS (Elastic Block Store)
-- [aws ec2 create-snapshot](http://docs.aws.amazon.com/cli/latest/reference/ec2/create-snapshot.html)
+- ec2-create-snapshot
 
 # CAVEATS
 
@@ -395,6 +395,10 @@ providing feature development, feedback, bug reports, and patches:
     Daniel Beardsley
     dileep-p
     theonlypippo
+    Tobias Lindgren
+    nbfowler
+    Mark Stosberg
+    Tim McEwan
 
 # AUTHOR/MAINTAINER
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -40,7 +40,7 @@ ec2-consistent-snapshot (0.61) saucy; urgency=low
 
 ec2-consistent-snapshot (0.60) saucy; urgency=low
 
-  * Add --tags option thanks to yalamber
+  * Add --tag option thanks to yalamber
     (fixes #27 on github)
 
  -- Eric Hammond <ehammond@thinksome.com>  Thu, 12 Jun 2014 12:20:43 -0700

--- a/debian/changelog
+++ b/debian/changelog
@@ -3,8 +3,12 @@ ec2-consistent-snapshot (0.67) vivid; urgency=medium
   * Try harder to find fsfreeze.
     thanks to Mark Stosberg
     (fixes #71 on github)
+  * Clean up --tag code and docs.
+    Show IAM role in --debug
+    thanks to Mark Stosberg
+    (fixes #65 on github)
 
- -- Eric Hammond <ehammond@thinksome.com>  Sat, 12 Dec 2015 19:57:40 -0800
+ -- Eric Hammond <ehammond@thinksome.com>  Sat, 12 Dec 2015 19:58:34 -0800
 
 ec2-consistent-snapshot (0.66) vivid; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -4,7 +4,8 @@ ec2-consistent-snapshot (0.67) vivid; urgency=medium
     thanks to Mark Stosberg
     (fixes #71 on github)
   * Clean up --tag code and docs.
-    Show IAM role in --debug
+    Show IAM role in --debug.
+    Show more info about SKIPPED snapshots.
     thanks to Mark Stosberg
     (fixes #65 on github)
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,8 @@ ec2-consistent-snapshot (0.68) UNRELEASED; urgency=medium
 
   * Quit supporting EOL'ed releases of Ubuntu
     thanks to Mark Stosberg
+  * Expanded MongoDB documentation
+    thanks to Mark Stosberg
 
  -- Eric Hammond <ehammond@thinksome.com>  Thu, 18 Aug 2016 10:06:29 -0700
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+ec2-consistent-snapshot (0.68) UNRELEASED; urgency=medium
+
+  * Quit supporting EOL'ed releases of Ubuntu
+    thanks to Mark Stosberg
+
+ -- Eric Hammond <ehammond@thinksome.com>  Thu, 18 Aug 2016 10:06:29 -0700
+
 ec2-consistent-snapshot (0.67) vivid; urgency=medium
 
   * Try harder to find fsfreeze.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+ec2-consistent-snapshot (0.64) UNRELEASED; urgency=medium
+
+  * Add --signature-version option.
+    thanks to Tobias Lindgren
+    (fixes #59 on github)
+
+ -- Eric Hammond <ehammond@thinksome.com>  Mon, 26 Oct 2015 19:17:39 -0700
+
 ec2-consistent-snapshot (0.63) trusty; urgency=medium
 
   * Update shabang line to use env perl.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+ec2-consistent-snapshot (0.69) wily; urgency=medium
+
+  * Add --mongo-timeout option
+    thanks to Ayush Goyal
+    (fixes #16 on github)
+
+ -- Eric Hammond <ehammond@thinksome.com>  Sat, 05 Nov 2016 12:33:29 -0700
+
 ec2-consistent-snapshot (0.68) wily; urgency=medium
 
   * Quit supporting EOL'ed releases of Ubuntu

--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,12 @@ ec2-consistent-snapshot (0.64) UNRELEASED; urgency=medium
   * Add --signature-version option.
     thanks to Tobias Lindgren
     (fixes #59 on github)
+  * Replace MongoDB::Connection and Admin with MongoClient
+    thanks to nbfowler
+    (pull request #62 on github)
+  * Reference aws-cli instead of old command
+    thanks to Mark Stosberg
+    (pull request #58 on github)
 
  -- Eric Hammond <ehammond@thinksome.com>  Mon, 26 Oct 2015 19:17:39 -0700
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+ec2-consistent-snapshot (0.66) vivid; urgency=medium
+
+  * Better document --mysql related options.
+    thanks to Mark Stosberg
+    (fixes #67 on github)
+
+ -- Eric Hammond <ehammond@thinksome.com>  Sat, 12 Dec 2015 19:44:23 -0800
+
 ec2-consistent-snapshot (0.65) vivid; urgency=medium
 
   * Add CreateTags to sample policy

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+ec2-consistent-snapshot (0.63) trusty; urgency=medium
+
+  * Update shabang line to use env perl.
+    thanks to theonlypippo
+    (fixes #55 on github)
+
+ -- Eric Hammond <ehammond@thinksome.com>  Fri, 05 Jun 2015 15:35:35 -0700
+
 ec2-consistent-snapshot (0.62) saucy; urgency=low
 
   * Improve cleanup on database query timeouts and interrupts

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-ec2-consistent-snapshot (0.64) UNRELEASED; urgency=medium
+ec2-consistent-snapshot (0.64) vivid; urgency=medium
 
   * Add --signature-version option.
     thanks to Tobias Lindgren
@@ -13,7 +13,7 @@ ec2-consistent-snapshot (0.64) UNRELEASED; urgency=medium
     thanks to Tim McEwan
     (pull request #50)
 
- -- Eric Hammond <ehammond@thinksome.com>  Mon, 26 Oct 2015 19:17:39 -0700
+ -- Eric Hammond <ehammond@thinksome.com>  Mon, 26 Oct 2015 19:55:12 -0700
 
 ec2-consistent-snapshot (0.63) trusty; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+ec2-consistent-snapshot (0.67) vivid; urgency=medium
+
+  * Try harder to find fsfreeze.
+    thanks to Mark Stosberg
+    (fixes #71 on github)
+
+ -- Eric Hammond <ehammond@thinksome.com>  Sat, 12 Dec 2015 19:57:40 -0800
+
 ec2-consistent-snapshot (0.66) vivid; urgency=medium
 
   * Better document --mysql related options.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 ec2-consistent-snapshot (0.64) vivid; urgency=medium
 
-  * Add --signature-version option.
+  * Add --signature-version option
     thanks to Tobias Lindgren
     (fixes #59 on github)
   * Replace MongoDB::Connection and Admin with MongoClient

--- a/debian/changelog
+++ b/debian/changelog
@@ -9,6 +9,9 @@ ec2-consistent-snapshot (0.64) UNRELEASED; urgency=medium
   * Reference aws-cli instead of old command
     thanks to Mark Stosberg
     (pull request #58 on github)
+  * Add --percona option for for FLUSH LOCAL TABLES issues
+    thanks to Tim McEwan
+    (pull request #50)
 
  -- Eric Hammond <ehammond@thinksome.com>  Mon, 26 Oct 2015 19:17:39 -0700
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+ec2-consistent-snapshot (0.65) vivid; urgency=medium
+
+  * Add CreateTags to sample policy
+    thanks to Mark Stosberg
+    (fixes #69 on github)
+
+ -- Eric Hammond <ehammond@thinksome.com>  Sat, 12 Dec 2015 19:30:45 -0800
+
 ec2-consistent-snapshot (0.64) vivid; urgency=medium
 
   * Add --signature-version option

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,11 +1,13 @@
-ec2-consistent-snapshot (0.68) UNRELEASED; urgency=medium
+ec2-consistent-snapshot (0.68) wily; urgency=medium
 
   * Quit supporting EOL'ed releases of Ubuntu
     thanks to Mark Stosberg
   * Expanded MongoDB documentation
     thanks to Mark Stosberg
+  * Add MongoDB library dependency
+    thanks to Mark Stosberg
 
- -- Eric Hammond <ehammond@thinksome.com>  Thu, 18 Aug 2016 10:06:29 -0700
+ -- Eric Hammond <ehammond@thinksome.com>  Fri, 16 Sep 2016 14:11:01 -0700
 
 ec2-consistent-snapshot (0.67) vivid; urgency=medium
 

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Vcs-Git: git@github.com:alestic/ec2-consistent-snapshot.git
 
 Package: ec2-consistent-snapshot
 Architecture: all
-Depends: ${misc:Depends}, xfsprogs, perl, libnet-amazon-ec2-perl, libfile-slurp-perl, libwww-perl, libdigest-hmac-perl, libparams-validate-perl, libxml-simple-perl, libmoose-perl, libcrypt-ssleay-perl, libdatetime-locale-perl, libdatetime-timezone-perl, libdbd-mysql-perl, libio-socket-ssl-perl
+Depends: ${misc:Depends}, xfsprogs, perl, libnet-amazon-ec2-perl, libfile-slurp-perl, libwww-perl, libdigest-hmac-perl, libparams-validate-perl, libxml-simple-perl, libmoose-perl, libcrypt-ssleay-perl, libdatetime-locale-perl, libdatetime-timezone-perl, libdbd-mysql-perl, libio-socket-ssl-perl, libmongodb-perl
 Description: Initiate consistent EBS snapshots in Amazon EC2
  The "ec2-consistent-snapshot" command can be used to initiate
  EBS (elastic block volume) snapshots in Amazon EC2.  In particular,

--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -367,7 +367,6 @@ sub _get_snapshot_tags {
      my $tag = $tags->[$index];
      my @sep_tags = split($tag_separator, $tag);
      if(scalar (@sep_tags) > 0){
-       my %snapshot_tag;
        for ( my $tag_index = 0; $tag_index < scalar (@sep_tags); ++$tag_index ) {
          my ($tag_key, $tag_value) = split('=', $sep_tags[$tag_index], 2);
          $snapshot_tag{$tag_key} = $tag_value;

--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -7,8 +7,11 @@ use warnings;
 (our $Prog) = ($0 =~ m%([^/]+)$%);
 use Getopt::Long;
 use Pod::Usage;
+use File::Basename qw(basename);
 use File::Slurp;
+use IO::Dir;
 use IO::Socket::SSL;
+use LWP::UserAgent qw();
 eval 'use Mozilla::CA';
 use Time::HiRes qw(ualarm usleep);
 use Net::Amazon::EC2 0.11;
@@ -35,6 +38,7 @@ my @descriptions               = ();
 my @tags                       = ();
 my $tag_separator              = ";";
 my @freeze_filesystem          = ();
+my @no_freeze_filesystem       = ();
 my $mongo                      = 0;
 my $mongo_username             = undef;
 my $mongo_password             = undef;
@@ -77,6 +81,7 @@ GetOptions(
   'tag=s'                        => \@tags,
   'xfs-filesystem=s'             => \@freeze_filesystem,
   'freeze-filesystem=s'          => \@freeze_filesystem,
+  'no-freeze-filesystem=s'       => \@no_freeze_filesystem,
   'mongo'                        => \$mongo,
   'mongo-username=s'             => \$mongo_username,
   'mongo-password=s'             => \$mongo_password,
@@ -105,7 +110,6 @@ my $filesystem_frozen = 0;
 pod2usage(1) if $Help;
 
 my @volume_ids = @ARGV;
-pod2usage(2) unless scalar @volume_ids;
 
 $ec2_endpoint ||= "https://ec2.$region.amazonaws.com" if $region;
 
@@ -123,6 +127,11 @@ $freeze_cmd    = "xfs_freeze"
 die "$Prog: ERROR: Can't find AWS access key or secret access key"
   unless $use_iam_role or ($aws_access_key_id and $aws_secret_access_key);
 $Debug and warn "$Prog: Using AWS access key: $aws_access_key_id\n";
+
+if ( scalar (@volume_ids) == 0 ) {
+  @volume_ids = discover_volume_ids($ec2_endpoint);
+}
+pod2usage(2) unless scalar @volume_ids;
 
 die "$Prog: ERROR: Descriptions count (", scalar (@descriptions),
     ") does not match volumes count (", scalar (@volume_ids), ")"
@@ -246,19 +255,26 @@ END {
 
 #---- METHODS ----
 
-sub ebs_snapshot {
-  my ($volume_ids, $ec2_endpoint, $descriptions, $tags) = @_;
+sub ec2_connection {
+  my ($ec2_endpoint) = @_;
 
   $Debug and warn "$Prog: ", scalar localtime, ": create EC2 object\n";
   $Debug and warn "$Prog: Endpoint: $ec2_endpoint\n" if $ec2_endpoint;
 
   # EC2 API object
-  my $ec2 = Net::Amazon::EC2->new(
+  return Net::Amazon::EC2->new(
     ((! $use_iam_role) ? (AWSAccessKeyId  => $aws_access_key_id,) : () ),
     ((! $use_iam_role) ? (SecretAccessKey => $aws_secret_access_key) : () ),
     ($ec2_endpoint ? (base_url => $ec2_endpoint) : ()),
     # ($Debug ? (debug => 1) : ()),
   );
+}
+
+sub ebs_snapshot {
+  my ($volume_ids, $ec2_endpoint, $descriptions, $tags) = @_;
+
+  # EC2 API object
+  my $ec2 = ec2_connection($ec2_endpoint);
 
   if ( not $ec2 ) {
     warn "$Prog: ERROR: Unable to create EC2 connection";
@@ -329,6 +345,135 @@ sub ebs_snapshot {
     }
   }
   return 1;
+}
+
+sub get {
+  my ($url) = @_;
+
+  my $ua = LWP::UserAgent->new;
+  $ua->timeout(2);
+
+  my $response = $ua->get($url);
+
+  my $content;
+  if ($response->is_success) {
+    $content = $response->decoded_content;
+  } else {
+    $Debug and warn "$Prog: ", scalar localtime,
+                    ": Unable to fetch $url: @{[$response->status_line]}\n";
+  }
+
+  return $content;
+}
+
+sub ec2_instance_description {
+  my ($ec2_endpoint) = @_;
+
+  $Debug and warn "$Prog: ", scalar localtime,
+                  ": Determining instance id\n";
+
+  my $instance_id = get('http://169.254.169.254/latest/meta-data/instance-id');
+  unless ( defined $instance_id ) {
+    warn "$Prog: ERROR: Unable to determine instance id\n";
+    return undef;
+  }
+
+  my $ec2 = ec2_connection($ec2_endpoint);
+
+  $Debug and warn "$Prog: ", scalar localtime,
+                  ": Fetching instance description for $instance_id\n";
+  my $reservations = $ec2->describe_instances(InstanceId => $instance_id);
+  unless ( defined($reservations) && scalar(@$reservations) == 1 ) {
+    warn "$Prog: ERROR: Unable to find reservation for $instance_id\n";
+    return undef;
+  }
+
+  return $reservations->[0]->instances_set->[0];
+}
+
+sub discover_volume_ids {
+  my ($ec2_endpoint) = @_;
+
+  $Debug and warn "$Prog: ", scalar localtime,
+                  ": No volume ids specified; discovering volume ids\n";
+
+  my @filesystems = (@freeze_filesystem, @no_freeze_filesystem);
+
+  if ( scalar(@filesystems) == 0 ) {
+    $Debug and warn "$Prog: ", scalar localtime,
+                    ": No filesystems specified; unable to discover volume ids\n";
+    return ();
+  }
+
+  $Debug and warn "$Prog: ", scalar localtime,
+                  ": Discovering volume ids for: @filesystems\n";
+
+  my $ec2_instance = ec2_instance_description($ec2_endpoint);
+  return () unless $ec2_instance;
+
+  # RunningInstances->block_device_mapping is a Maybe[ArrayRef]
+  unless ( $ec2_instance->block_device_mapping ) {
+    warn "$Prog: ERROR: Unable to find block device mappings for ", $ec2_instance->instance_id, "\n";
+    return ();
+  }
+
+  my %ebs_volume_ids = ();
+  for my $bd ( @{$ec2_instance->block_device_mapping} ) {
+    # BlockDeviceMapping->ebs is a Maybe[ArrayRef]
+    $ebs_volume_ids{$bd->device_name} = $bd->ebs->volume_id if $bd->ebs;
+  }
+
+  unless ( %ebs_volume_ids ) {
+    warn "$Prog: ERROR: Unable to find EBS block devices for ", $ec2_instance->instance_id, "\n";
+    return ();
+  }
+
+  if ( $Debug ) {
+    warn "$Prog: ", scalar localtime,
+         ": Found EBS block devices for ", $ec2_instance->instance_id, ": \n";
+    for my $dev (sort keys %ebs_volume_ids) {
+      warn "$Prog: ", scalar localtime, ":     ", $ebs_volume_ids{$dev}, " ", $dev, "\n";
+    }
+  }
+
+  my $volume_ids;
+  for my $fs (@filesystems) {
+    my $device = qx(mountpoint -dq "$fs");
+    chomp $device;
+    unless ($? == 0 && $device) {
+      warn "$Prog: ERROR: $fs is not a mount point\n";
+      return ();
+    }
+
+    # Check sysfs for a /slaves directory; if we find one, assume we have a
+    # compound device (e.g. LVM or Raid), otherwise, get the basename of the
+    # symlink at /sys/dev/block/MAJOR:MINOR
+    my $slaves = IO::Dir->new("/sys/dev/block/$device/slaves");
+    my @devices = ();
+    push @devices, grep { !/^\./ } $slaves->read() if defined($slaves);
+    push @devices, basename readlink("/sys/dev/block/$device") unless scalar(@devices);
+
+    if ( scalar(@devices) == 0 ) {
+      warn "$Prog: ERROR: Unable to determine devices for mount $fs\n";
+      return ();
+    }
+
+    for my $device (@devices) {
+      my $ec2_device = "/dev/$device";
+      $ec2_device =~ s/\bxvd/sd/;
+
+      my $volume_id = $ebs_volume_ids{$ec2_device};
+
+      unless ( defined $volume_id ) {
+        warn "$Prog: ERROR: Unable to determine volume id for device $device in mount $fs\n";
+        return ();
+      }
+
+      push @$volume_ids, $volume_id;
+    }
+  }
+
+  return @$volume_ids;
 }
 
 #
@@ -813,6 +958,19 @@ fsfreeze comes with newer versions of util-linux.
 You may specify this option multiple times if you need to freeze multiple
 filesystems on the the EBS volume(s).
 
+If no EBS volume ids are specified as command arguments, the specified
+mountpoints will be used along with mount points passed to
+--no-freeze-filesystem to determine the volume ids.
+
+=item --no-freeze-filesystem MOUNTPOINT
+
+Indicates that the filesystem at the specified mount point should be used for
+volume id discovery if no volume ids are specified as arguments, but that it
+should not be frozen.
+
+You may specify this options multiple times if you need to discover EBS volumes
+for multiple filesystems.
+
 =item --mongo
 
 Indicates that the volume contains data files for a running Mongo
@@ -983,6 +1141,11 @@ Snapshot two volumes with customized descriptions:
    --description "Description 2nd Volume"                     \
    vol-VOL1 vol-VOL2
 
+Snapshot a volume without specifying a volume id (requires ec2:DescribeInstances
+permission):
+
+ ec2-consistent-snapshot --freeze-filesystem /vol
+
 =head1 ENVIRONMENT
 
 =over
@@ -1053,6 +1216,18 @@ On Ubuntu 8.04 Hardy, use the following commands instead:
 
 The default values can be accepted for most of the prompts, though it
 is necessary to select a CPAN mirror on Hardy.
+
+=head1 VOLUME DISCOVERY
+
+If no EBS volume ids are passed as arguments to ec2-consistent-snapshot, it
+will attempt to discover the volume ids based on the mount points passed to
+--no-freeze-filesystem and --freeze-filesystem.
+
+In order to determine the volume ids, ec2-consistent-snapshot first makes a
+call to the EC2 instance metadata service to determine the instance's id. Next,
+it makes a call to the DescribeInstances EC2 api to get the list of volumes
+attached to the instance. It then compares the device names for each attachment
+with a list of device names determined using mountpoint(1) and sysfs.
 
 =head1 SEE ALSO
 

--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -301,7 +301,7 @@ sub ebs_snapshot {
 
     # Snapshot
     $Debug and
-      warn "$Prog: ", scalar localtime, ": ec2-create-snapshot $volume_id\n";
+      warn "$Prog: ", scalar localtime, ": aws ec2 create-snapshot $volume_id\n";
     if ( $Noaction ) {
       warn "snapshot SKIPPED (--noaction)\n";
       next VOLUME;
@@ -1261,7 +1261,7 @@ with a list of device names determined using mountpoint(1) and sysfs.
 
 =item Amazon EC2 EBS (Elastic Block Store)
 
-=item ec2-create-snapshot
+=item L<aws ec2 create-snapshot|http://docs.aws.amazon.com/cli/latest/reference/ec2/create-snapshot.html>
 
 =back
 

--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -50,6 +50,7 @@ my $mysql_username             = undef;
 my $mysql_password             = undef;
 my $mysql_host                 = undef;
 my $mysql_stop                 = 0;
+my $percona                    = 0;
 my $snapshot_timeout           = 10.0; # seconds
 my $lock_timeout               =  0.5; # seconds
 my $lock_tries                 = 60;
@@ -91,6 +92,7 @@ GetOptions(
   'mysql-password=s'             => \$mysql_password,
   'mysql-host=s'                 => \$mysql_host,
   'mysql-stop'                   => \$mysql_stop,
+  'percona'                      => \$percona,
   'snapshot-timeout=s'           => \$snapshot_timeout,
   'lock-timeout=s'               => \$lock_timeout,
   'lock-tries=s'                 => \$lock_tries,
@@ -112,6 +114,8 @@ $ec2_endpoint ||= "https://ec2.$region.amazonaws.com" if $region;
 my $freeze_cmd = "fsfreeze";
 $freeze_cmd    = "xfs_freeze"
     if $freeze_cmd and system("which $freeze_cmd >/dev/null") != 0;
+
+$mysql = 1 if $percona; # Percona is a variant of MySQL
 
 #---- MAIN ----
 
@@ -464,25 +468,44 @@ sub mysql_lock {
   # as this can interfere with long-running queries on the slaves.
   $mysql_dbh->do(q{ SET SQL_LOG_BIN=0 }) unless $Noaction;
 
-  # Try a flush first without locking so the later flush with lock
-  # goes faster.  This may not be needed as it seems to interfere with
-  # some statements anyway.
-  sql_timeout_retry(
-    q{ FLUSH LOCAL TABLES },
-    "MySQL flush",
-    $lock_timeout,
-    $lock_tries,
-    $lock_sleep,
-  );
+  if ( $percona ) {
+    # http://www.percona.com/blog/2014/03/11/introducing-backup-locks-percona-server-2/
+    sql_timeout_retry(
+      q{ LOCK TABLES FOR BACKUP },
+      "Percona table lock",
+      $lock_timeout,
+      $lock_tries,
+      $lock_sleep,
+    );
 
-  # Get a lock on the entire database
-  sql_timeout_retry(
-    q{ FLUSH LOCAL TABLES WITH READ LOCK },
-    "MySQL flush & lock",
-    $lock_timeout,
-    $lock_tries,
-    $lock_sleep,
-  );
+    sql_timeout_retry(
+      q{ LOCK BINLOG FOR BACKUP },
+      "Percona binlog lock",
+      $lock_timeout,
+      $lock_tries,
+      $lock_sleep,
+    );
+  } else {
+    # Try a flush first without locking so the later flush with lock
+    # goes faster.  This may not be needed as it seems to interfere with
+    # some statements anyway.
+    sql_timeout_retry(
+      q{ FLUSH LOCAL TABLES },
+      "MySQL flush",
+      $lock_timeout,
+      $lock_tries,
+      $lock_sleep,
+    );
+
+    # Get a lock on the entire database
+    sql_timeout_retry(
+      q{ FLUSH LOCAL TABLES WITH READ LOCK },
+      "MySQL flush & lock",
+      $lock_timeout,
+      $lock_tries,
+      $lock_sleep,
+    );
+  }
 
   my ($mysql_logfile, $mysql_position,
       $mysql_binlog_do_db, $mysql_binlog_ignore_db);
@@ -532,7 +555,10 @@ sub mysql_unlock {
   my ($mysql_dbh) = @_;
 
   $Debug and warn "$Prog: ", scalar localtime, ": MySQL unlock\n";
-  $mysql_dbh->do(q{ UNLOCK TABLES }) unless $Noaction;
+  unless ( $Noaction ) {
+    $mysql_dbh->do(q{ UNLOCK TABLES });
+    $mysql_dbh->do(q{ UNLOCK BINLOG }) if $percona;
+  }
 
 }
 
@@ -869,6 +895,12 @@ with --mysql-stop
 Indicates that the volume contains data files for a running MySQL
 database.  The database is shutdown before the snapshot is initiated
 and restarted afterwards. [EXPERIMENTAL]
+
+=item --percona
+
+Indicates that the volume contains data files for a running Percona/MySQL
+database, which will be locked using Percona's unique backup locking commands.
+Note: this sets '--mysql' automatically.
 
 =item --snapshot-timeout SECONDS
 

--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -1324,6 +1324,7 @@ providing feature development, feedback, bug reports, and patches:
   Tobias Lindgren
   nbfowler
   Mark Stosberg
+  Tim McEwan
 
 =head1 AUTHOR/MAINTAINER
 

--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -1017,6 +1017,11 @@ and restarted afterwards. [EXPERIMENTAL]
 Indicates that the volume contains data files for a running MySQL
 database, which will be flushed and locked during the snapshot.
 
+To connect, we will first look in `--mysql-defaults-file`, if provided.
+Otherwise, the values of `--mysql-host`, `--mysql-socket`, `--mysql-username`
+and `--mysql-password` will be used to build the connection string.
+
+
 =item --mysql-defaults-file FILE
 
 MySQL defaults file, containing host, username and password, this
@@ -1043,9 +1048,11 @@ with --mysql-stop
 
 =item --mysql-stop
 
-Indicates that the volume contains data files for a running MySQL
-database.  The database is shutdown before the snapshot is initiated
-and restarted afterwards. [EXPERIMENTAL]
+Indicates that the volume contains data files for a running MySQL database.
+The database is shutdown using `/usr/bin/mysqladmin stop` before the snapshot
+is initiated and restarted afterwards using `/etc/init.d/mysql start`. Suitable
+for running as root when a few seconds of downtime are acceptable.
+[EXPERIMENTAL]
 
 =item --percona
 

--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -982,6 +982,18 @@ descriptions of multiple volumes snapshots. If specified multiple
 times descriptions count has to match volumes count and they will be
 applied on the same order.
 
+=item --tag "KEY=VALUE;KEY2=VALUE2"
+
+If the --tag option is given once, the provided tags will be applied to all
+created snapshots.  Tag keys and values must be separated by '='. Multiple tags
+must be separated by ';'.
+
+If the --tag option is provided more than once, the tags for each use of --tag
+will apply to each volume in the order that the volumes are provided.
+
+To check how your tags will be applied, you can use the --noaction flag before
+actually running a snapshot.
+
 =item  --freeze-filesystem MOUNTPOINT
 
 =item --xfs-filesystem MOUNTPOINT [OBSOLESCENT form of the same option]

--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -1263,6 +1263,7 @@ without specifying the volume ID.
                 "Effect": "Allow",
                 "Action": [
                     "ec2:CreateSnapshot",
+                    "ec2:CreateTags",
                     "ec2:DescribeInstances"
                 ],
                 "Resource": [

--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -341,20 +341,12 @@ sub ebs_snapshot {
       return undef;
     } elsif ( $snapshot->can('snapshot_id') ) {
       $snapshot_id = $snapshot->snapshot_id;
-      if (scalar (@tags) > 0){
-        my $tag = $$tags[$index];
-        my @sep_tags = split($tag_separator, $tag);
-        if(scalar (@sep_tags) > 0){
-          my %snapshot_tag;
-          for ( my $tag_index = 0; $tag_index < scalar (@sep_tags); ++$tag_index ) {
-            my ($tag_key, $tag_value) = split('=', $sep_tags[$tag_index], 2);
-            $snapshot_tag{$tag_key} = $tag_value;
-          }
-          $ec2->create_tags(
+      my $snapshot_tag = _get_snapshot_tags(\@tags,$index);
+      if (keys %$snapshot_tag){
+        $ec2->create_tags(
             ResourceId    => $snapshot_id,
-            Tags          => \%snapshot_tag,
-          );
-        }
+            Tags          => $snapshot_tag,
+        );
       }
       $Quiet or print "$snapshot_id\n";
     } else {
@@ -365,6 +357,24 @@ sub ebs_snapshot {
     }
   }
   return 1;
+}
+
+# Given array of tags and an index, parse them and return tags for a specific volumme
+sub _get_snapshot_tags {
+   my ($tags,$index) = @_;
+   my %snapshot_tag;	
+   if (scalar @$tags > 0){
+     my $tag = $tags->[$index];
+     my @sep_tags = split($tag_separator, $tag);
+     if(scalar (@sep_tags) > 0){
+       my %snapshot_tag;
+       for ( my $tag_index = 0; $tag_index < scalar (@sep_tags); ++$tag_index ) {
+         my ($tag_key, $tag_value) = split('=', $sep_tags[$tag_index], 2);
+         $snapshot_tag{$tag_key} = $tag_value;
+       }
+     }
+   }
+   return \%snapshot_tag;	
 }
 
 sub get {

--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # Copyright (C) 2009-2014 Eric Hammond <ehammond@thinksome.com>
 #

--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -477,14 +477,6 @@ sub mysql_lock {
       $lock_tries,
       $lock_sleep,
     );
-
-    sql_timeout_retry(
-      q{ LOCK BINLOG FOR BACKUP },
-      "Percona binlog lock",
-      $lock_timeout,
-      $lock_tries,
-      $lock_sleep,
-    );
   } else {
     # Try a flush first without locking so the later flush with lock
     # goes faster.  This may not be needed as it seems to interfere with
@@ -555,10 +547,7 @@ sub mysql_unlock {
   my ($mysql_dbh) = @_;
 
   $Debug and warn "$Prog: ", scalar localtime, ": MySQL unlock\n";
-  unless ( $Noaction ) {
-    $mysql_dbh->do(q{ UNLOCK TABLES });
-    $mysql_dbh->do(q{ UNLOCK BINLOG }) if $percona;
-  }
+  $mysql_dbh->do(q{ UNLOCK TABLES }) unless $Noaction;
 
 }
 

--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -539,8 +539,6 @@ EOM
       close(MYSQLMASTERSTATUS);
     }
   }
-
-  return ($mysql_logfile, $mysql_position);
 }
 
 sub mysql_unlock {

--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -1271,6 +1271,7 @@ without specifying the volume ID.
             }
         ]
     }
+
 If you get an "unauthorized" error when using the C<--use-iam-role> option, you
 can use the C<--debug> option to confirm whether it was the
 C<DescribeInstances> or C<CreateSnapshot> API call that failed.
@@ -1372,7 +1373,7 @@ Eric Hammond <ehammond@thinksome.com>
 
 =head1 LICENSE
 
-Copyright 2009-2014 Eric Hammond <ehammond@thinksome.com>
+Copyright 2009-2015 Eric Hammond <ehammond@thinksome.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -117,9 +117,7 @@ my @volume_ids = @ARGV;
 
 $ec2_endpoint ||= "https://ec2.$region.amazonaws.com" if $region;
 
-my $freeze_cmd = "fsfreeze";
-$freeze_cmd    = "xfs_freeze"
-    if $freeze_cmd and system("which $freeze_cmd >/dev/null") != 0;
+my $freeze_cmd = _get_fsfreeze();
 
 $mysql = 1 if $percona; # Percona is a variant of MySQL
 die "$Prog: ERROR: The --percona and --mysql-master-status-file options are mutually exclusive. ",
@@ -891,6 +889,27 @@ sub ec2_error_message {
 
     return $error;
 }
+
+# If fsfreeze is not in $PATH, try some paths which are usually excluded from the cron $PATH before
+# falling back to xfs_freeze
+sub _get_fsfreeze {
+  my $freeze_cmd = "fsfreeze";
+
+  my $freeze_not_in_path = (system("which $freeze_cmd >/dev/null") != 0);
+  if ($freeze_not_in_path) {
+    if (-x '/usr/sbin/fsfreeze')  {
+      $freeze_cmd = '/usr/sbin/fsfreeze';
+    }
+    elsif (-x '/sbin/fsfreeze') {
+      $freeze_cmd = '/sbin/fsfreeze';
+    }
+    else {
+      $freeze_cmd    = "xfs_freeze";
+    }
+  }
+  return $freeze_cmd;
+}
+
 
 
 =head1 NAME

--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -308,26 +308,29 @@ sub ebs_snapshot {
     # Snapshot
     $Debug and
       warn "$Prog: ", scalar localtime, ": aws ec2 create-snapshot $volume_id\n";
-    if ( $Noaction ) {
-      warn "snapshot SKIPPED (--noaction)\n";
-      next VOLUME;
-    }
 
     my $snapshot;
-    eval {
-      local $SIG{ALRM} = sub { ualarm(0); die "timeout\n" };
-      ualarm($snapshot_timeout * 1_000_000);
-      $snapshot = $ec2->create_snapshot(
-        VolumeId    => $volume_id,
-        Description => $description,
-      );
-      ualarm(0);
-    };
-    ualarm(0);
-    if ( $@  ){
-      warn "$Prog: ERROR: create_snapshot: ", ec2_error_message($@);
-      return undef;
+    if ( !$Noaction ) {
+    	eval {
+    	  local $SIG{ALRM} = sub { ualarm(0); die "timeout\n" };
+    	  ualarm($snapshot_timeout * 1_000_000);
+    	  $snapshot = $ec2->create_snapshot(
+    	    VolumeId    => $volume_id,
+    	    Description => $description,
+    	  );
+    	  ualarm(0);
+    	};
+    	ualarm(0);
+    	if ( $@  ){
+    	  warn "$Prog: ERROR: create_snapshot: ", ec2_error_message($@);
+    	  return undef;
+    	}
     }
+    else {
+      my $snapshot_tag = $tags[$index] || "None.";
+      warn "snapshot SKIPPED volume_id: $volume_id; description: $description; tags: $snapshot_tag (--noaction)\n";
+      next VOLUME;
+    }  
 
     my $snapshot_id;
     if ( not defined $snapshot ) {

--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -486,15 +486,13 @@ sub mongo_connect {
   MongoDB->import;
   require MongoDB::Database;
   MongoDB::Database->import;
-  require MongoDB::Admin;
-  MongoDB::Admin->import;
 
   $mongo_host ||= 'localhost';
 
   $Debug and warn "$Prog: ", scalar localtime,
                   ": mongo connect on ${mongo_host}:${mongo_port}\n";
 
-  my $mongo_conn = MongoDB::Connection->new(host => "${mongo_host}:${mongo_port}")
+  my $mongo_conn = MongoDB::MongoClient->new(host => "${mongo_host}:${mongo_port}")
     or die "$Prog: ERROR: Unable to connect to mongo"
          . " on $mongo_host";
 
@@ -504,11 +502,7 @@ sub mongo_connect {
            . " on $mongo_host as $mongo_username";
   }
 
-  my $mongo_dbh = MongoDB::Admin->new(connection => $mongo_conn)
-    or die "$Prog: ERROR: Unable to get Mongo admin connection"
-           . " on $mongo_host";
-
-  return $mongo_dbh;
+  return $mongo_conn;
 }
 
 sub mongo_lock {
@@ -520,7 +514,7 @@ sub mongo_lock {
   if ( $Noaction ) {
     warn "mongo lock SKIPPED (--noaction)\n";
   }
-  $mongo_dbh->fsync_lock();
+  $mongo_dbh->fsync({lock => 1});
 
   $Debug and warn "$Prog: ", scalar localtime, ": mongo locked\n";
 
@@ -536,7 +530,7 @@ sub mongo_unlock {
   if ( $Noaction ) {
     warn "mongo unlock SKIPPED (--noaction)\n";
   }
-  $mongo_dbh->unlock();
+  $mongo_dbh->fsync_unlock();
 
   $Debug and warn "$Prog: ", scalar localtime, ": mongo unlocked\n";
 

--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -116,6 +116,9 @@ $freeze_cmd    = "xfs_freeze"
     if $freeze_cmd and system("which $freeze_cmd >/dev/null") != 0;
 
 $mysql = 1 if $percona; # Percona is a variant of MySQL
+die "$Prog: ERROR: The --percona and --mysql-master-status-file options are mutually exclusive. ",
+                  "Percona locking does not give accurate binlog location."
+  if $percona and defined($mysql_master_status_file);
 
 #---- MAIN ----
 
@@ -477,6 +480,10 @@ sub mysql_lock {
       $lock_tries,
       $lock_sleep,
     );
+
+    $mysql_dbh->do(q{ SET SQL_LOG_BIN=1 }) unless $Noaction;
+    return # do not store/print binlog info as can be erroneous
+
   } else {
     # Try a flush first without locking so the later flush with lock
     # goes faster.  This may not be needed as it seems to interfere with

--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -1046,20 +1046,45 @@ database, which will be flushed and locked during the snapshot.
 
 =item --mongo-host HOST
 
+Define host used with the `--mongo` option.
+
+Defaults to 'localhost'.
+
 =item --mongo-port PORT
+
+Define MongoDB port used with the `--mongo` option.
+
+Defaults to 27017
 
 =item --mongo-username USER
 
+Define MongoDB username used with the `--mongo` option.
+
+Defaults to `undef`. Required only if authentication is required.
+
 =item --mongo-password PASS
 
-Mongo host, port, username, and password used to flush logs if there
-is authentication required on the admin database.
+Define MongoDB password used with the `--mongo` option.
+
+Defaults to `undef`.  Required only if authentication is required.
 
 =item --mongo-stop
 
 Indicates that the volume contains data files for a running Mongo
 instance.  The instance is shutdown before the snapshot is initiated
 and restarted afterwards. [EXPERIMENTAL]
+
+Uses the `--mongo-init` option to stop and start the database ignores
+all other Mongo-related options
+
+=item --mongo-init
+
+The command used to stop and start mongo.
+
+Defaults to `/etc/init.d/mongod`.
+
+Used only if `--mongo-stop` is used. The `--mongo-init` command is passed the 'stop' and 'start'
+options during to the stop/start process.
 
 =item --mysql
 

--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -1296,6 +1296,7 @@ providing feature development, feedback, bug reports, and patches:
   yalamber
   Daniel Beardsley
   dileep-p
+  theonlypippo
 
 =head1 AUTHOR/MAINTAINER
 

--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -275,6 +275,7 @@ sub ec2_connection {
     ((! $use_iam_role) ? (AWSAccessKeyId  => $aws_access_key_id,) : () ),
     ((! $use_iam_role) ? (SecretAccessKey => $aws_secret_access_key) : () ),
     ($ec2_endpoint ? (base_url => $ec2_endpoint) : ()),
+    ($region ? (region => $region) : ()),
     ($signature_version ? (signature_version => $signature_version) : ()),
     # ($Debug ? (debug => 1) : ()),
   );

--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -33,7 +33,7 @@ my $aws_secret_access_key_file = $ENV{AWS_SECRET_ACCESS_KEY};
 my $aws_credentials_file       = $ENV{AWS_CREDENTIALS};
 my $use_iam_role               = 0;
 my $region                     = undef;
-my $signature_version          = 4;
+my $signature_version          = undef;
 my $ec2_endpoint               = undef;
 my @descriptions               = ();
 my @tags                       = ();
@@ -275,8 +275,7 @@ sub ec2_connection {
     ((! $use_iam_role) ? (AWSAccessKeyId  => $aws_access_key_id,) : () ),
     ((! $use_iam_role) ? (SecretAccessKey => $aws_secret_access_key) : () ),
     ($ec2_endpoint ? (base_url => $ec2_endpoint) : ()),
-    signature_version => $signature_version,
-    region => $region,
+    ($signature_version ? (signature_version => $signature_version) : ()),
     # ($Debug ? (debug => 1) : ()),
   );
 }

--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -135,7 +135,13 @@ die "$Prog: ERROR: The --percona and --mysql-master-status-file options are mutu
 );
 die "$Prog: ERROR: Can't find AWS access key or secret access key"
   unless $use_iam_role or ($aws_access_key_id and $aws_secret_access_key);
-$Debug and warn "$Prog: Using AWS access key: $aws_access_key_id\n";
+if ( $Debug && $use_iam_role ) {
+    warn "$Prog: Authenticating with IAM role\n";
+}
+elsif ( $Debug ) {
+    warn "$Prog: Using AWS access key: $aws_access_key_id\n";
+}
+
 
 if ( scalar (@volume_ids) == 0 ) {
   @volume_ids = discover_volume_ids($ec2_endpoint);

--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -46,6 +46,7 @@ my $mongo_password             = undef;
 my $mongo_host                 = undef;
 my $mongo_port                 = 27017;
 my $mongo_stop                 = 0;
+my $mongo_timeout              = 30000;
 my $mysql                      = 0;
 #my $mysql_defaults_file        = "$ENV{HOME}/.my.cnf";
 my $mysql_defaults_file        = undef;
@@ -91,6 +92,7 @@ GetOptions(
   'mongo-host=s'                 => \$mongo_host,
   'mongo-port=s'                 => \$mongo_port,
   'mongo-stop'                   => \$mongo_stop,
+  'mongo-timeout=i'              => \$mongo_timeout,
   'mysql'                        => \$mysql,
   'mysql-defaults-file=s'        => \$mysql_defaults_file,
   'mysql-socket=s'               => \$mysql_socket,
@@ -185,7 +187,7 @@ my $mongo_dbh = undef;
 if ( $mongo_stop ) {
   $mongo_stopped = mongo_stop();
 } elsif ( $mongo ) {
-  $mongo_dbh = mongo_connect($mongo_host, $mongo_port, $mongo_username, $mongo_password);
+  $mongo_dbh = mongo_connect($mongo_host, $mongo_port, $mongo_username, $mongo_password, $mongo_timeout);
   mongo_lock($mongo_dbh);
 }
 
@@ -507,7 +509,7 @@ sub discover_volume_ids {
 # Mongo
 #
 sub mongo_connect {
-  my ($mongo_host, $mongo_port, $mongo_username, $mongo_password) = @_;
+  my ($mongo_host, $mongo_port, $mongo_username, $mongo_password, $mongo_timeout) = @_;
 
   require MongoDB;
   MongoDB->import;
@@ -519,7 +521,7 @@ sub mongo_connect {
   $Debug and warn "$Prog: ", scalar localtime,
                   ": mongo connect on ${mongo_host}:${mongo_port}\n";
 
-  my $mongo_conn = MongoDB::MongoClient->new(host => "${mongo_host}:${mongo_port}")
+  my $mongo_conn = MongoDB::MongoClient->new(host => "${mongo_host}:${mongo_port}", query_timeout => $mongo_timeout)
     or die "$Prog: ERROR: Unable to connect to mongo"
          . " on $mongo_host";
 

--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -1296,6 +1296,8 @@ providing feature development, feedback, bug reports, and patches:
   dileep-p
   theonlypippo
   Tobias Lindgren
+  nbfowler
+  Mark Stosberg
 
 =head1 AUTHOR/MAINTAINER
 

--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -656,7 +656,7 @@ sub mysql_lock {
     $mysql_dbh->do(q{ SET SQL_LOG_BIN=1 }) unless $Noaction;
     return # do not store/print binlog info as can be erroneous
 
-  } else if ( $mysql_stop_slave ) {
+  } elsif ( $mysql_stop_slave ) {
     # STOP SLAVE blocks until the current replication group is done processing
     # so we only really need to run it once with a high timeout
     sql_timeout_retry(

--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -33,6 +33,7 @@ my $aws_secret_access_key_file = $ENV{AWS_SECRET_ACCESS_KEY};
 my $aws_credentials_file       = $ENV{AWS_CREDENTIALS};
 my $use_iam_role               = 0;
 my $region                     = undef;
+my $signature_version          = 4;
 my $ec2_endpoint               = undef;
 my @descriptions               = ();
 my @tags                       = ();
@@ -76,6 +77,7 @@ GetOptions(
   'aws-credentials-file=s'       => \$aws_credentials_file,
   'use-iam-role'                 => \$use_iam_role,
   'region=s'                     => \$region,
+  'signature-version=s'          => \$signature_version,
   'ec2-endpoint=s'               => \$ec2_endpoint,
   'description=s'                => \@descriptions,
   'tag=s'                        => \@tags,
@@ -266,6 +268,8 @@ sub ec2_connection {
     ((! $use_iam_role) ? (AWSAccessKeyId  => $aws_access_key_id,) : () ),
     ((! $use_iam_role) ? (SecretAccessKey => $aws_secret_access_key) : () ),
     ($ec2_endpoint ? (base_url => $ec2_endpoint) : ()),
+    signature_version => $signature_version,
+    region => $region,
     # ($Debug ? (debug => 1) : ()),
   );
 }
@@ -1291,6 +1295,7 @@ providing feature development, feedback, bug reports, and patches:
   Daniel Beardsley
   dileep-p
   theonlypippo
+  Tobias Lindgren
 
 =head1 AUTHOR/MAINTAINER
 

--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -945,7 +945,8 @@ $AWS_CREDENTIALS environment variable or the value $HOME/.awssecret
 =item  --use-iam-role
 
 The instance is part of an IAM role that that has permission to create
-snapshots so there is no need to specify access key or secret.
+snapshots so there is no need to specify access key or secret. See L</IAM ROLES>
+section for an example Managed Policy with the required permissions.
 
 =item --region REGION
 
@@ -1240,6 +1241,45 @@ On Ubuntu 8.04 Hardy, use the following commands instead:
 
 The default values can be accepted for most of the prompts, though it
 is necessary to select a CPAN mirror on Hardy.
+
+=for markdown <a name="iam-roles"></a>
+
+=head1 IAM ROLES
+
+When authenticating using a IAM Role your role must have the appropriate
+permissions.  You can create a single IAM Managed Policy that allows the
+necessary permissions and attach the managed policy to each IAM role you would
+like to allow to create EC2 snapshots.
+
+The following policy allows both creating the snapshots as the read-only
+C<DescribeInstances> permission which is required if you want to snapshot a volume
+without specifying the volume ID.
+
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "1",
+                "Effect": "Allow",
+                "Action": [
+                    "ec2:CreateSnapshot",
+                    "ec2:DescribeInstances"
+                ],
+                "Resource": [
+                    "*"
+                ]
+            }
+        ]
+    }
+If you get an "unauthorized" error when using the C<--use-iam-role> option, you
+can use the C<--debug> option to confirm whether it was the
+C<DescribeInstances> or C<CreateSnapshot> API call that failed.
+
+You might also use IAM policies to allow automating deleting old snapshots
+through another tool. Using a separate policy is recommended for that. By
+putting the "delete" permission in the same policy, you would be allowing
+someone with access to one of your EC2 instances to delete the backups of the
+instance volumes. Instead, carefully restrict the delete permission.
 
 =head1 VOLUME DISCOVERY
 


### PR DESCRIPTION
It appears that there has been some extensive development on the
upstream. Changes include:
- Help output changes (many of them)
- Tagging support, which we may be able to use
- Percona Specific feautes such as `LOCK BINLOG FOR BACKUP`

I first merged our branch into upstream and these were the conflicts:


Merge ifixit-production into upstream

Conflicts:
ec2-consistent-snapshot
   * upstream changed indentation of the ualarm business and we had
     modified that code
   * upstream added another if() branch to mysql_lock and so did we
   * upstream added documentation in the same place we did