### PR TITLE
--percona: allow master-status-file option

### DIFF
--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -124,9 +124,6 @@ $ec2_endpoint ||= "https://ec2.$region.amazonaws.com" if $region;
 my $freeze_cmd = _get_fsfreeze();
 
 $mysql = 1 if $percona; # Percona is a variant of MySQL
-die "$Prog: ERROR: The --percona and --mysql-master-status-file options are mutually exclusive. ",
-                  "Percona locking does not give accurate binlog location."
-  if $percona and defined($mysql_master_status_file);
 
 #---- MAIN ----
 
@@ -654,10 +651,6 @@ sub mysql_lock {
       $lock_tries,
       $lock_sleep,
     );
-
-    $mysql_dbh->do(q{ SET SQL_LOG_BIN=1 }) unless $Noaction;
-    return # do not store/print binlog info as can be erroneous
-
   } elsif ( $mysql_stop_slave ) {
     # STOP SLAVE blocks until the current replication group is done processing
     # so we only really need to run it once with a high timeout


### PR DESCRIPTION
As of percona 5.6.26, LTFB flushes binlog coordinates and thus
grabbing the master status info is safe.

See the release notes: https://www.percona.com/doc/percona-server/5.6/release-notes/Percona-Server-5.6.26-74.0.html#new-features
And the docs: https://www.percona.com/doc/percona-server/5.6/management/backup_locks.html#backup-safe-binlog-information